### PR TITLE
Align site colors with autism theme

### DIFF
--- a/app/components/index.css
+++ b/app/components/index.css
@@ -16,24 +16,24 @@
     --popover: 23 86% 97%;     /* Warm Mist */
     --popover-foreground: 20 22% 39%;  /* Clay Taupe */
 
-    --primary: 19 77% 83%;     /* Peach Cream */
-    --primary-foreground: 20 22% 39%;  /* Clay Taupe */
+    --primary: 201 100% 36%;   /* Autism Blue */
+    --primary-foreground: 210 40% 98%; /* White */
 
-    --secondary: 8 79% 72%;    /* Soft Coral */
-    --secondary-foreground: 0 0% 100%;
+    --secondary: 45 100% 62%;  /* Autism Yellow */
+    --secondary-foreground: 20 22% 39%; /* Clay Taupe */
 
     --muted: 23 77% 89%;       /* Powder Apricot */
     --muted-foreground: 23 17% 59%;  /* Sienna Gray */
 
-    --accent: 37 100% 84%;     /* Honey Blush */
+    --accent: 19 77% 83%;      /* Peach Cream */
     --accent-foreground: 20 22% 39%;  /* Clay Taupe */
 
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 356 80% 56%; /* Autism Red */
     --destructive-foreground: 210 40% 98%;
 
     --border: 23 17% 59%;      /* Sienna Gray */
     --input: 23 17% 59%;       /* Sienna Gray */
-    --ring: 19 77% 83%;        /* Peach Cream */
+    --ring: 201 100% 36%;      /* Autism Blue */
 
     --radius: 0.5rem;
   }
@@ -60,7 +60,7 @@
   }
   
   .autism-btn-primary {
-    @apply bg-autism-peach-cream hover:bg-autism-soft-coral text-autism-clay-taupe font-medium px-5 py-2.5 rounded-md transition-colors;
+    @apply bg-autism-blue hover:bg-autism-peach-cream text-white font-medium px-5 py-2.5 rounded-md transition-colors;
   }
   
   .autism-btn-secondary {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -64,15 +64,20 @@ export default {
 					ring: 'hsl(var(--sidebar-ring))'
 				},
 				// Custom color scheme
-				autism: {
-					'peach-cream': '#F6BFA6', // Primary brand color
-					'soft-coral': '#F48C7F',  // Secondary accent
-					'warm-mist': '#FFF4EE',   // Calming balance/background
-					'honey-blush': '#FFDFAF', // Highlight/call-out
-					'powder-apricot': '#FAD6C4', // Support accent
-					'clay-taupe': '#7A5B4C',  // Accessible text/borders
-					'sienna-gray': '#A88C80', // Gentle contrast
-				}
+                                autism: {
+                                        'peach-cream': '#F6BFA6', // Primary brand color
+                                        'soft-coral': '#F48C7F',  // Secondary accent
+                                        'warm-mist': '#FFF4EE',   // Calming balance/background
+                                        'honey-blush': '#FFDFAF', // Highlight/call-out
+                                        'powder-apricot': '#FAD6C4', // Support accent
+                                        'clay-taupe': '#7A5B4C',  // Accessible text/borders
+                                        'sienna-gray': '#A88C80', // Gentle contrast
+                                        // National autism colors
+                                        blue: '#0077B6',
+                                        yellow: '#FFD23F',
+                                        red: '#E63946',
+                                        navy: '#1D3557',
+                                }
 			},
 			borderRadius: {
 				lg: 'var(--radius)',


### PR DESCRIPTION
## Summary
- add national autism colors to tailwind palette
- make the primary button blue and keep peach as the hover color
- set new CSS variables so the primary color is blue and accent remains peach

## Testing
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685b21aeee348333b3750d518dd746b2